### PR TITLE
#207 shopDetail.js: img1일때 왼쪽 화살표 버튼 사라짐 해결

### DIFF
--- a/src/main/webapp/assets/js/shop/shopDetail.js
+++ b/src/main/webapp/assets/js/shop/shopDetail.js
@@ -172,10 +172,10 @@ $('#prevBtn').click(function () {
   const totalImgNum = document.getElementsByClassName('carouselImg').length;
   document.getElementById(`carousel-item-${imgNum}`).classList.add('hidden');
   imgNum -= 1;
-  console.log('prv-imgNum = ' + imgNum);
   document.getElementById(`carousel-item-${imgNum}`).classList.remove('hidden');
   
   if (imgNum == 1) {
     document.getElementById('prevBtn').classList.add('invisible');
+    document.getElementById('nextBtn').classList.remove('invisible');
   }
 });


### PR DESCRIPTION
이미지 다음 버튼 클릭 후 다시 왼쪽 버튼 클릭해서 img-1이 되었을때 왼쪽 화살표 버튼 사라짐 해결